### PR TITLE
replace string,string pairs with generic json in MetaData Tab

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -210,7 +210,7 @@ const App = () => {
     useState<AuthDebuggerState>(EMPTY_DEBUGGER_STATE);
 
   // Meta data state - persisted in localStorage
-  const [metaData, setMetaData] = useState<Record<string, string>>(() => {
+  const [metaData, setMetaData] = useState<Record<string, unknown>>(() => {
     const savedMetaData = localStorage.getItem("lastMetaData");
     if (savedMetaData) {
       try {
@@ -226,7 +226,7 @@ const App = () => {
     setAuthState((prev) => ({ ...prev, ...updates }));
   };
 
-  const handleMetaDataChange = (newMetaData: Record<string, string>) => {
+  const handleMetaDataChange = (newMetaData: Record<string, unknown>) => {
     setMetaData(newMetaData);
     localStorage.setItem("lastMetaData", JSON.stringify(newMetaData));
   };

--- a/client/src/components/MetaDataTab.tsx
+++ b/client/src/components/MetaDataTab.tsx
@@ -1,118 +1,157 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Trash2, Plus } from "lucide-react";
-
-interface MetaDataEntry {
-  key: string;
-  value: string;
-}
+import JsonEditor from "@/components/JsonEditor";
 
 interface MetaDataTabProps {
-  metaData: Record<string, string>;
-  onMetaDataChange: (metaData: Record<string, string>) => void;
+  metaData: Record<string, unknown>;
+  onMetaDataChange: (metaData: Record<string, unknown>) => void;
 }
 
 const MetaDataTab: React.FC<MetaDataTabProps> = ({
   metaData,
   onMetaDataChange,
 }) => {
-  const [entries, setEntries] = useState<MetaDataEntry[]>(() => {
-    return Object.entries(metaData).map(([key, value]) => ({ key, value }));
+  const stringifyCompact = (
+    value: Record<string, unknown> | null | undefined,
+  ) => {
+    if (!value || Object.keys(value).length === 0) {
+      return "";
+    }
+
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "";
+    }
+  };
+
+  const stringifyPretty = (value: Record<string, unknown>) => {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return "";
+    }
+  };
+
+  const initialCompact = stringifyCompact(metaData);
+  const [jsonValue, setJsonValue] = useState<string>(() => {
+    if (!initialCompact) {
+      return "";
+    }
+
+    return stringifyPretty(metaData);
   });
 
-  const addEntry = () => {
-    setEntries([...entries, { key: "", value: "" }]);
-  };
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const lastMetaDataStringRef = useRef<string>(initialCompact);
 
-  const removeEntry = (index: number) => {
-    const newEntries = entries.filter((_, i) => i !== index);
-    setEntries(newEntries);
-    updateMetaData(newEntries);
-  };
+  useEffect(() => {
+    const compact = stringifyCompact(metaData);
 
-  const updateEntry = (
-    index: number,
-    field: "key" | "value",
-    value: string,
-  ) => {
-    const newEntries = [...entries];
-    newEntries[index][field] = value;
-    setEntries(newEntries);
-    updateMetaData(newEntries);
-  };
+    if (compact === lastMetaDataStringRef.current) {
+      return;
+    }
 
-  const updateMetaData = (newEntries: MetaDataEntry[]) => {
-    const metaDataObject: Record<string, string> = {};
-    newEntries.forEach(({ key, value }) => {
-      if (key.trim() && value.trim()) {
-        metaDataObject[key.trim()] = value.trim();
+    lastMetaDataStringRef.current = compact;
+
+    if (!compact) {
+      setJsonValue("");
+      setJsonError(null);
+      return;
+    }
+
+    if (metaData) {
+      const pretty = stringifyPretty(metaData);
+      setJsonValue(pretty);
+      setJsonError(null);
+    }
+  }, [metaData]);
+
+  const handleJsonChange = (value: string) => {
+    setJsonValue(value);
+
+    if (!value.trim()) {
+      onMetaDataChange({});
+      lastMetaDataStringRef.current = "";
+      setJsonError(null);
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(value);
+
+      if (
+        parsed === null ||
+        Array.isArray(parsed) ||
+        typeof parsed !== "object"
+      ) {
+        setJsonError("Meta data must be a JSON object");
+        return;
       }
-    });
-    onMetaDataChange(metaDataObject);
+
+      onMetaDataChange(parsed);
+      lastMetaDataStringRef.current = JSON.stringify(parsed);
+      setJsonError(null);
+    } catch {
+      setJsonError("Invalid JSON format");
+    }
+  };
+
+  const handlePrettyClick = () => {
+    if (!jsonValue.trim()) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(jsonValue);
+
+      if (
+        parsed === null ||
+        Array.isArray(parsed) ||
+        typeof parsed !== "object"
+      ) {
+        setJsonError("Meta data must be a JSON object");
+        return;
+      }
+
+      const pretty = stringifyPretty(parsed);
+      setJsonValue(pretty);
+      onMetaDataChange(parsed);
+      lastMetaDataStringRef.current = JSON.stringify(parsed);
+      setJsonError(null);
+    } catch {
+      setJsonError("Invalid JSON format");
+    }
   };
 
   return (
     <TabsContent value="metadata">
       <div className="space-y-4">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <div>
             <h3 className="text-lg font-semibold">Meta Data</h3>
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              Key-value pairs that will be included in all MCP requests
+              Provide an object containing key-value pairs that will be included
+              in all MCP requests.
             </p>
           </div>
-          <Button onClick={addEntry} size="sm">
-            <Plus className="w-4 h-4 mr-2" />
-            Add Entry
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={handlePrettyClick}
+            className="flex-shrink-0"
+          >
+            Pretty
           </Button>
         </div>
 
-        <div className="space-y-3">
-          {entries.map((entry, index) => (
-            <div key={index} className="flex items-center space-x-2">
-              <div className="flex-1">
-                <Label htmlFor={`key-${index}`} className="sr-only">
-                  Key
-                </Label>
-                <Input
-                  id={`key-${index}`}
-                  placeholder="Key"
-                  value={entry.key}
-                  onChange={(e) => updateEntry(index, "key", e.target.value)}
-                />
-              </div>
-              <div className="flex-1">
-                <Label htmlFor={`value-${index}`} className="sr-only">
-                  Value
-                </Label>
-                <Input
-                  id={`value-${index}`}
-                  placeholder="Value"
-                  value={entry.value}
-                  onChange={(e) => updateEntry(index, "value", e.target.value)}
-                />
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => removeEntry(index)}
-              >
-                <Trash2 className="w-4 h-4" />
-              </Button>
-            </div>
-          ))}
-        </div>
-
-        {entries.length === 0 && (
-          <div className="text-center py-8">
-            <p className="text-gray-500 dark:text-gray-400 mb-4">
-              No meta data entries. Click "Add Entry" to add key-value pairs.
-            </p>
-          </div>
-        )}
+        <JsonEditor
+          value={jsonValue}
+          onChange={handleJsonChange}
+          error={jsonError || undefined}
+        />
       </div>
     </TabsContent>
   );

--- a/client/src/components/__tests__/MetaDataTab.test.tsx
+++ b/client/src/components/__tests__/MetaDataTab.test.tsx
@@ -3,6 +3,32 @@ import "@testing-library/jest-dom";
 import MetaDataTab from "../MetaDataTab";
 import { Tabs } from "@/components/ui/tabs";
 
+jest.mock("react-simple-code-editor", () => {
+  return function MockCodeEditor({
+    value,
+    onValueChange: onValueChange,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+  }) {
+    return (
+      <textarea
+        data-testid="json-editor"
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+      />
+    );
+  };
+});
+
+jest.mock("prismjs", () => ({
+  highlight: (code: string) => code,
+  languages: { json: {} },
+}));
+
+jest.mock("prismjs/components/prism-json", () => {});
+jest.mock("prismjs/themes/prism.css", () => {});
+
 describe("MetaDataTab", () => {
   const defaultProps = {
     metaData: {},
@@ -28,38 +54,22 @@ describe("MetaDataTab", () => {
       expect(screen.getByText("Meta Data")).toBeInTheDocument();
       expect(
         screen.getByText(
-          "Key-value pairs that will be included in all MCP requests",
+          "Provide an object containing key-value pairs that will be included in all MCP requests.",
         ),
       ).toBeInTheDocument();
     });
 
-    it("should render Add Entry button", () => {
+    it("should render Pretty button", () => {
       renderMetaDataTab();
 
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      expect(addButton).toBeInTheDocument();
+      const prettyButton = screen.getByRole("button", { name: /pretty/i });
+      expect(prettyButton).toBeInTheDocument();
     });
 
-    it("should show empty state message when no entries exist", () => {
+    it("should render JSON editor", () => {
       renderMetaDataTab();
 
-      expect(
-        screen.getByText(
-          'No meta data entries. Click "Add Entry" to add key-value pairs.',
-        ),
-      ).toBeInTheDocument();
-    });
-
-    it("should not show empty state message when entries exist", () => {
-      renderMetaDataTab({
-        metaData: { key1: "value1" },
-      });
-
-      expect(
-        screen.queryByText(
-          'No meta data entries. Click "Add Entry" to add key-value pairs.',
-        ),
-      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("json-editor")).toBeInTheDocument();
     });
   });
 
@@ -72,487 +82,174 @@ describe("MetaDataTab", () => {
 
       renderMetaDataTab({ metaData: initialMetaData });
 
-      expect(screen.getByDisplayValue("API_KEY")).toBeInTheDocument();
-      expect(screen.getByDisplayValue("test-key")).toBeInTheDocument();
-      expect(screen.getByDisplayValue("VERSION")).toBeInTheDocument();
-      expect(screen.getByDisplayValue("1.0.0")).toBeInTheDocument();
+      const editor = screen.getByTestId("json-editor") as HTMLTextAreaElement;
+      expect(editor.value).toContain("API_KEY");
+      expect(editor.value).toContain("test-key");
+      expect(editor.value).toContain("VERSION");
+      expect(editor.value).toContain("1.0.0");
     });
 
-    it("should render multiple entries in correct order", () => {
-      const initialMetaData = {
-        FIRST: "first-value",
-        SECOND: "second-value",
-        THIRD: "third-value",
-      };
-
-      renderMetaDataTab({ metaData: initialMetaData });
-
-      const keyInputs = screen.getAllByPlaceholderText("Key");
-      const valueInputs = screen.getAllByPlaceholderText("Value");
-
-      expect(keyInputs).toHaveLength(3);
-      expect(valueInputs).toHaveLength(3);
-
-      // Check that entries are rendered in the order they appear in the object
-      const entries = Object.entries(initialMetaData);
-      entries.forEach(([key, value], index) => {
-        expect(keyInputs[index]).toHaveValue(key);
-        expect(valueInputs[index]).toHaveValue(value);
+    it("should pretty print metadata by default", () => {
+      renderMetaDataTab({
+        metaData: { firstKey: "value" },
       });
+
+      const editor = screen.getByTestId("json-editor") as HTMLTextAreaElement;
+      expect(editor.value).toBe(`{
+  "firstKey": "value"
+}`);
     });
   });
 
-  describe("Adding Entries", () => {
-    it("should add a new empty entry when Add Entry button is clicked", () => {
-      renderMetaDataTab();
+  describe("Editing JSON", () => {
+    it("should call onMetaDataChange when valid JSON is entered", () => {
+      const onMetaDataChange = jest.fn();
+      renderMetaDataTab({ onMetaDataChange });
 
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      fireEvent.click(addButton);
-
-      const keyInputs = screen.getAllByPlaceholderText("Key");
-      const valueInputs = screen.getAllByPlaceholderText("Value");
-
-      expect(keyInputs).toHaveLength(1);
-      expect(valueInputs).toHaveLength(1);
-      expect(keyInputs[0]).toHaveValue("");
-      expect(valueInputs[0]).toHaveValue("");
-    });
-
-    it("should add multiple entries when Add Entry button is clicked multiple times", () => {
-      renderMetaDataTab();
-
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-
-      fireEvent.click(addButton);
-      fireEvent.click(addButton);
-      fireEvent.click(addButton);
-
-      const keyInputs = screen.getAllByPlaceholderText("Key");
-      const valueInputs = screen.getAllByPlaceholderText("Value");
-
-      expect(keyInputs).toHaveLength(3);
-      expect(valueInputs).toHaveLength(3);
-    });
-
-    it("should hide empty state message after adding first entry", () => {
-      renderMetaDataTab();
-
-      expect(
-        screen.getByText(
-          'No meta data entries. Click "Add Entry" to add key-value pairs.',
-        ),
-      ).toBeInTheDocument();
-
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      fireEvent.click(addButton);
-
-      expect(
-        screen.queryByText(
-          'No meta data entries. Click "Add Entry" to add key-value pairs.',
-        ),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe("Removing Entries", () => {
-    it("should render remove button for each entry", () => {
-      renderMetaDataTab({
-        metaData: { key1: "value1", key2: "value2" },
+      const editor = screen.getByTestId("json-editor");
+      fireEvent.change(editor, {
+        target: { value: '{"key":"value"}' },
       });
 
-      const removeButtons = screen.getAllByRole("button", { name: "" }); // Trash icon buttons have no text
-      expect(removeButtons).toHaveLength(2);
+      expect(onMetaDataChange).toHaveBeenCalledWith({ key: "value" });
     });
 
-    it("should remove entry when remove button is clicked", () => {
+    it("should show error for invalid JSON", () => {
+      renderMetaDataTab();
+
+      const editor = screen.getByTestId("json-editor");
+      fireEvent.change(editor, {
+        target: { value: '{"key": }' },
+      });
+
+      expect(screen.getByText("Invalid JSON format")).toBeInTheDocument();
+    });
+
+    it("should not call onMetaDataChange when JSON is invalid", () => {
+      const onMetaDataChange = jest.fn();
+      renderMetaDataTab({ onMetaDataChange });
+
+      const editor = screen.getByTestId("json-editor");
+      fireEvent.change(editor, {
+        target: { value: '{"key": }' },
+      });
+
+      expect(onMetaDataChange).not.toHaveBeenCalled();
+    });
+
+    it("should clear error when JSON becomes valid", () => {
+      renderMetaDataTab();
+
+      const editor = screen.getByTestId("json-editor");
+      fireEvent.change(editor, {
+        target: { value: '{"key": }' },
+      });
+
+      expect(screen.getByText("Invalid JSON format")).toBeInTheDocument();
+
+      fireEvent.change(editor, {
+        target: { value: '{"key": "value"}' },
+      });
+
+      expect(screen.queryByText("Invalid JSON format")).not.toBeInTheDocument();
+    });
+
+    it("should clear metadata when input is emptied", () => {
       const onMetaDataChange = jest.fn();
       renderMetaDataTab({
-        metaData: { key1: "value1", key2: "value2" },
+        metaData: { key: "value" },
         onMetaDataChange,
       });
 
-      const removeButtons = screen.getAllByRole("button", { name: "" });
-      fireEvent.click(removeButtons[0]);
+      const editor = screen.getByTestId("json-editor");
 
-      expect(onMetaDataChange).toHaveBeenCalledWith({ key2: "value2" });
-    });
-
-    it("should remove correct entry when multiple entries exist", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({
-        metaData: {
-          FIRST: "first-value",
-          SECOND: "second-value",
-          THIRD: "third-value",
-        },
-        onMetaDataChange,
+      fireEvent.change(editor, {
+        target: { value: "" },
       });
-
-      const removeButtons = screen.getAllByRole("button", { name: "" });
-      fireEvent.click(removeButtons[1]); // Remove second entry
-
-      expect(onMetaDataChange).toHaveBeenCalledWith({
-        FIRST: "first-value",
-        THIRD: "third-value",
-      });
-    });
-
-    it("should show empty state message after removing all entries", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({
-        metaData: { key1: "value1" },
-        onMetaDataChange,
-      });
-
-      const removeButton = screen.getByRole("button", { name: "" });
-      fireEvent.click(removeButton);
 
       expect(onMetaDataChange).toHaveBeenCalledWith({});
     });
-  });
 
-  describe("Editing Entries", () => {
-    it("should update key when key input is changed", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({
-        metaData: { oldKey: "value1" },
-        onMetaDataChange,
-      });
-
-      const keyInput = screen.getByDisplayValue("oldKey");
-      fireEvent.change(keyInput, { target: { value: "newKey" } });
-
-      expect(onMetaDataChange).toHaveBeenCalledWith({ newKey: "value1" });
-    });
-
-    it("should update value when value input is changed", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({
-        metaData: { key1: "oldValue" },
-        onMetaDataChange,
-      });
-
-      const valueInput = screen.getByDisplayValue("oldValue");
-      fireEvent.change(valueInput, { target: { value: "newValue" } });
-
-      expect(onMetaDataChange).toHaveBeenCalledWith({ key1: "newValue" });
-    });
-
-    it("should handle editing multiple entries independently", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({
-        metaData: {
-          key1: "value1",
-          key2: "value2",
-        },
-        onMetaDataChange,
-      });
-
-      const keyInputs = screen.getAllByPlaceholderText("Key");
-      const valueInputs = screen.getAllByPlaceholderText("Value");
-
-      // Edit first entry key
-      fireEvent.change(keyInputs[0], { target: { value: "newKey1" } });
-      expect(onMetaDataChange).toHaveBeenCalledWith({
-        newKey1: "value1",
-        key2: "value2",
-      });
-
-      // Clear mock to test second edit independently
-      onMetaDataChange.mockClear();
-
-      // Edit second entry value
-      fireEvent.change(valueInputs[1], { target: { value: "newValue2" } });
-      expect(onMetaDataChange).toHaveBeenCalledWith({
-        newKey1: "value1",
-        key2: "newValue2",
-      });
-    });
-  });
-
-  describe("Data Validation and Trimming", () => {
-    it("should trim whitespace from keys and values", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({ onMetaDataChange });
-
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      fireEvent.click(addButton);
-
-      const keyInput = screen.getByPlaceholderText("Key");
-      const valueInput = screen.getByPlaceholderText("Value");
-
-      fireEvent.change(keyInput, { target: { value: "  trimmedKey  " } });
-      fireEvent.change(valueInput, { target: { value: "  trimmedValue  " } });
-
-      expect(onMetaDataChange).toHaveBeenCalledWith({
-        trimmedKey: "trimmedValue",
-      });
-    });
-
-    it("should exclude entries with empty keys or values after trimming", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({ onMetaDataChange });
-
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      fireEvent.click(addButton);
-      fireEvent.click(addButton);
-
-      const keyInputs = screen.getAllByPlaceholderText("Key");
-      const valueInputs = screen.getAllByPlaceholderText("Value");
-
-      // First entry: valid key and value
-      fireEvent.change(keyInputs[0], { target: { value: "validKey" } });
-      fireEvent.change(valueInputs[0], { target: { value: "validValue" } });
-
-      // Second entry: empty key (should be excluded)
-      fireEvent.change(keyInputs[1], { target: { value: "" } });
-      fireEvent.change(valueInputs[1], { target: { value: "someValue" } });
-
-      expect(onMetaDataChange).toHaveBeenCalledWith({
-        validKey: "validValue",
-      });
-    });
-
-    it("should exclude entries with whitespace-only keys or values", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({ onMetaDataChange });
-
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      fireEvent.click(addButton);
-      fireEvent.click(addButton);
-
-      const keyInputs = screen.getAllByPlaceholderText("Key");
-      const valueInputs = screen.getAllByPlaceholderText("Value");
-
-      // First entry: valid key and value
-      fireEvent.change(keyInputs[0], { target: { value: "validKey" } });
-      fireEvent.change(valueInputs[0], { target: { value: "validValue" } });
-
-      // Second entry: whitespace-only key (should be excluded)
-      fireEvent.change(keyInputs[1], { target: { value: "   " } });
-      fireEvent.change(valueInputs[1], { target: { value: "someValue" } });
-
-      expect(onMetaDataChange).toHaveBeenCalledWith({
-        validKey: "validValue",
-      });
-    });
-
-    it("should handle mixed valid and invalid entries", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({ onMetaDataChange });
-
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      fireEvent.click(addButton);
-      fireEvent.click(addButton);
-      fireEvent.click(addButton);
-
-      const keyInputs = screen.getAllByPlaceholderText("Key");
-      const valueInputs = screen.getAllByPlaceholderText("Value");
-
-      // First entry: valid
-      fireEvent.change(keyInputs[0], { target: { value: "key1" } });
-      fireEvent.change(valueInputs[0], { target: { value: "value1" } });
-
-      // Second entry: empty key (invalid)
-      fireEvent.change(keyInputs[1], { target: { value: "" } });
-      fireEvent.change(valueInputs[1], { target: { value: "value2" } });
-
-      // Third entry: valid
-      fireEvent.change(keyInputs[2], { target: { value: "key3" } });
-      fireEvent.change(valueInputs[2], { target: { value: "value3" } });
-
-      expect(onMetaDataChange).toHaveBeenCalledWith({
-        key1: "value1",
-        key3: "value3",
-      });
-    });
-  });
-
-  describe("Input Accessibility", () => {
-    it("should have proper labels for screen readers", () => {
-      renderMetaDataTab({
-        metaData: { key1: "value1" },
-      });
-
-      const keyLabel = screen.getByLabelText("Key", { selector: "input" });
-      const valueLabel = screen.getByLabelText("Value", { selector: "input" });
-
-      expect(keyLabel).toBeInTheDocument();
-      expect(valueLabel).toBeInTheDocument();
-    });
-
-    it("should have unique IDs for each input pair", () => {
-      renderMetaDataTab({
-        metaData: {
-          key1: "value1",
-          key2: "value2",
-        },
-      });
-
-      const keyInputs = screen.getAllByPlaceholderText("Key");
-      const valueInputs = screen.getAllByPlaceholderText("Value");
-
-      expect(keyInputs[0]).toHaveAttribute("id", "key-0");
-      expect(keyInputs[1]).toHaveAttribute("id", "key-1");
-      expect(valueInputs[0]).toHaveAttribute("id", "value-0");
-      expect(valueInputs[1]).toHaveAttribute("id", "value-1");
-    });
-
-    it("should have proper placeholder text", () => {
+    it("should display object validation error when JSON is not an object", () => {
       renderMetaDataTab();
 
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      fireEvent.click(addButton);
+      const editor = screen.getByTestId("json-editor");
+      fireEvent.change(editor, {
+        target: { value: "[]" },
+      });
 
-      const keyInput = screen.getByPlaceholderText("Key");
-      const valueInput = screen.getByPlaceholderText("Value");
-
-      expect(keyInput).toHaveAttribute("placeholder", "Key");
-      expect(valueInput).toHaveAttribute("placeholder", "Value");
+      expect(
+        screen.getByText("Meta data must be a JSON object"),
+      ).toBeInTheDocument();
     });
   });
 
-  describe("Edge Cases", () => {
-    it("should handle special characters in keys and values", () => {
+  describe("Pretty Button", () => {
+    it("should format the JSON when clicked", () => {
       const onMetaDataChange = jest.fn();
       renderMetaDataTab({ onMetaDataChange });
 
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      fireEvent.click(addButton);
+      const editor = screen.getByTestId("json-editor") as HTMLTextAreaElement;
 
-      const keyInput = screen.getByPlaceholderText("Key");
-      const valueInput = screen.getByPlaceholderText("Value");
-
-      fireEvent.change(keyInput, {
-        target: { value: "key-with-special@chars!" },
-      });
-      fireEvent.change(valueInput, {
-        target: { value: "value with spaces & symbols $%^" },
+      fireEvent.change(editor, {
+        target: { value: '{"key":"value"}' },
       });
 
-      expect(onMetaDataChange).toHaveBeenCalledWith({
-        "key-with-special@chars!": "value with spaces & symbols $%^",
-      });
+      const prettyButton = screen.getByRole("button", { name: /pretty/i });
+
+      fireEvent.click(prettyButton);
+
+      expect(editor.value).toBe(`{
+  "key": "value"
+}`);
+      expect(onMetaDataChange).toHaveBeenLastCalledWith({ key: "value" });
     });
 
-    it("should handle unicode characters", () => {
+    it("should not do anything when editor is empty", () => {
       const onMetaDataChange = jest.fn();
       renderMetaDataTab({ onMetaDataChange });
 
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      fireEvent.click(addButton);
+      const editor = screen.getByTestId("json-editor") as HTMLTextAreaElement;
+      const prettyButton = screen.getByRole("button", { name: /pretty/i });
 
-      const keyInput = screen.getByPlaceholderText("Key");
-      const valueInput = screen.getByPlaceholderText("Value");
+      fireEvent.click(prettyButton);
 
-      fireEvent.change(keyInput, { target: { value: "🔑_key" } });
-      fireEvent.change(valueInput, { target: { value: "值_value_🎯" } });
-
-      expect(onMetaDataChange).toHaveBeenCalledWith({
-        "🔑_key": "值_value_🎯",
-      });
+      expect(editor.value).toBe("");
+      expect(onMetaDataChange).not.toHaveBeenCalled();
     });
 
-    it("should handle very long keys and values", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({ onMetaDataChange });
+    it("should show error when JSON cannot be parsed on pretty click", () => {
+      renderMetaDataTab();
 
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      fireEvent.click(addButton);
-
-      const keyInput = screen.getByPlaceholderText("Key");
-      const valueInput = screen.getByPlaceholderText("Value");
-
-      const longKey = "A".repeat(100);
-      const longValue = "B".repeat(500);
-
-      fireEvent.change(keyInput, { target: { value: longKey } });
-      fireEvent.change(valueInput, { target: { value: longValue } });
-
-      expect(onMetaDataChange).toHaveBeenCalledWith({
-        [longKey]: longValue,
+      const editor = screen.getByTestId("json-editor");
+      fireEvent.change(editor, {
+        target: { value: '{"key": }' },
       });
-    });
 
-    it("should handle duplicate keys by keeping the last one", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({ onMetaDataChange });
+      const prettyButton = screen.getByRole("button", { name: /pretty/i });
 
-      const addButton = screen.getByRole("button", { name: /add entry/i });
-      fireEvent.click(addButton);
-      fireEvent.click(addButton);
+      fireEvent.click(prettyButton);
 
-      const keyInputs = screen.getAllByPlaceholderText("Key");
-      const valueInputs = screen.getAllByPlaceholderText("Value");
-
-      // Set same key for both entries
-      fireEvent.change(keyInputs[0], { target: { value: "duplicateKey" } });
-      fireEvent.change(valueInputs[0], { target: { value: "firstValue" } });
-
-      fireEvent.change(keyInputs[1], { target: { value: "duplicateKey" } });
-      fireEvent.change(valueInputs[1], { target: { value: "secondValue" } });
-
-      // The second value should overwrite the first
-      expect(onMetaDataChange).toHaveBeenCalledWith({
-        duplicateKey: "secondValue",
-      });
+      expect(screen.getByText("Invalid JSON format")).toBeInTheDocument();
     });
   });
 
-  describe("Integration with Parent Component", () => {
-    it("should not call onMetaDataChange when component mounts with existing data", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({
-        metaData: { key1: "value1" },
-        onMetaDataChange,
-      });
+  describe("Props Synchronization", () => {
+    it("should update editor contents when props change", () => {
+      const { rerender } = renderMetaDataTab({});
 
-      expect(onMetaDataChange).not.toHaveBeenCalled();
-    });
+      expect(screen.getByTestId("json-editor")).toHaveValue("");
 
-    it("should call onMetaDataChange only when user makes changes", () => {
-      const onMetaDataChange = jest.fn();
-      renderMetaDataTab({
-        metaData: { key1: "value1" },
-        onMetaDataChange,
-      });
-
-      // Should not be called on mount
-      expect(onMetaDataChange).not.toHaveBeenCalled();
-
-      // Should be called when user changes value
-      const valueInput = screen.getByDisplayValue("value1");
-      fireEvent.change(valueInput, { target: { value: "newValue" } });
-
-      expect(onMetaDataChange).toHaveBeenCalledTimes(1);
-      expect(onMetaDataChange).toHaveBeenCalledWith({ key1: "newValue" });
-    });
-
-    it("should maintain internal state when props change (component doesn't sync with prop changes)", () => {
-      const { rerender } = renderMetaDataTab({
-        metaData: { key1: "value1" },
-      });
-
-      expect(screen.getByDisplayValue("key1")).toBeInTheDocument();
-      expect(screen.getByDisplayValue("value1")).toBeInTheDocument();
-
-      // Rerender with different props - component should maintain its internal state
-      // This is the intended behavior since useState initializer only runs once
       rerender(
         <Tabs defaultValue="metadata">
-          <MetaDataTab
-            metaData={{ key2: "value2", key3: "value3" }}
-            onMetaDataChange={jest.fn()}
-          />
+          <MetaDataTab {...defaultProps} metaData={{ nextKey: "nextValue" }} />
         </Tabs>,
       );
 
-      // The component should still show the original values since it maintains internal state
-      expect(screen.getByDisplayValue("key1")).toBeInTheDocument();
-      expect(screen.getByDisplayValue("value1")).toBeInTheDocument();
-      // The new prop values should not be displayed
-      expect(screen.queryByDisplayValue("key2")).not.toBeInTheDocument();
-      expect(screen.queryByDisplayValue("value2")).not.toBeInTheDocument();
+      const editor = screen.getByTestId("json-editor") as HTMLTextAreaElement;
+      expect(editor.value).toBe(`{
+  "nextKey": "nextValue"
+}`);
     });
   });
 });

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -79,7 +79,7 @@ interface UseConnectionOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getRoots?: () => any[];
   defaultLoggingLevel?: LoggingLevel;
-  metaData?: Record<string, string>;
+  metaData?: Record<string, unknown>;
 }
 
 export function useConnection({


### PR DESCRIPTION
Hi,
thanks again for your work on that, to be able to really use it properly, a generic json fits better for _meta than string, string pairs, so i changed your MetaDataTab component accordingly.